### PR TITLE
fix: force the DEVICE to be brick to fix screen stretching on older MinUI installs

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -261,6 +261,11 @@ network_loop() {
 
 main() {
     trap "killall sdl2imgshow" EXIT INT TERM HUP QUIT
+
+    if [ "$PLATFORM" = "tg3040" ] && [ -z "$DEVICE" ]; then
+        export DEVICE="brick"
+    fi
+
     while true; do
         selection="$(main_screen)"
         exit_code=$?


### PR DESCRIPTION
Due to linking against newer MinUI libraries, we need to force the DEVICE to be brick so that runtime changes the screen resolution to the correct thing on the Brick. The newer libraries merge the Brick and TSP, and default to TSP values if DEVICE isn't brick.